### PR TITLE
cleanup: improve library version bounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -805,6 +805,7 @@ dependencies = [
  "maplit",
  "num-traits",
  "ratatui",
+ "regex",
  "serde",
  "serde_json",
  "sha1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ ratatui = "0.23.0"
 unicode-width = "0.1"
 
 # Features: serde
-serde = { version = "1.0", features = ["serde_derive"], optional = true }
+serde = { version = "1.0.100", features = ["serde_derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
 
 # Features: scm-diff-editor
@@ -42,6 +42,8 @@ eyre = "0.6"
 insta = "1.34"
 maplit = "1.0"
 serde_json = "1.0"
+
+regex = "1.5.1"  # resolve some build issue in transitive dependencies with minimal versions
 
 [[bin]]
 name = "scm-diff-editor"


### PR DESCRIPTION
Tested with

```
cargo +nightly generate-lockfile -Zminimal-versions && cargo nextest run --workspace
```

Note that there also exists the `-Zdirect-minimal-versions` flag to only update immediate dependencies. That invocation with `-Zdirect-minimal-versions` doesn't produce any changes to the lockfile, so we don't actually need this PR.
