### PR TITLE
[1/1] cleanup: fix `cargo clippy` warning

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -9,7 +9,7 @@ impl UsizeExt for usize {
     }
 
     fn clamp_into_u16(self) -> u16 {
-        if self > u16::MAX.try_into().unwrap() {
+        if self > u16::MAX.into() {
             u16::MAX
         } else {
             self.try_into().unwrap()


### PR DESCRIPTION
**Stack:**

* https://github.com/arxanas/scm-record/pull/20


---

cleanup: fix `cargo clippy` warning

