### PR TITLE
Fix TestFilesystem::read_dir_diff_paths

### DIFF
--- a/src/scm_diff_editor.rs
+++ b/src/scm_diff_editor.rs
@@ -1091,8 +1091,12 @@ mod tests {
             Ok(self
                 .files
                 .keys()
-                .filter(|path| path.starts_with(left) || path.starts_with(right))
-                .cloned()
+                .filter_map(|path| {
+                    path.strip_prefix(left.to_str().unwrap())
+                        .ok()
+                        .or_else(|| path.strip_prefix(right.to_str().unwrap()).ok())
+                })
+                .map(|p| p.to_path_buf())
                 .collect())
         }
 


### PR DESCRIPTION
This function collects the files present in the `left` and `right` directories. It should return the path suffix with the `left` and `right` prefix stripped. This is necessary because `process_opts` will add the `left` and `right` prefix back to the paths returned by `read_dir_diff_paths`. If we don't strip the prefix, we will end up with invalid paths where the prefix is duplicated.

This went unnoticed since the current tests don't diff directories. I will add a test that diffs directories in a subsequent commit.