### PR TITLE
Allow "left arrow" and "h" to collapse text sections

### DIFF
--- a/scm-record/src/ui.rs
+++ b/scm-record/src/ui.rs
@@ -248,13 +248,13 @@ impl From<crossterm::event::Event> for Event {
 
             Event::Key(KeyEvent {
                 code: KeyCode::Left | KeyCode::Char('h'),
-                modifiers: KeyModifiers::NONE,
+                modifiers: KeyModifiers::NONE | KeyModifiers::CONTROL,
                 kind: KeyEventKind::Press,
                 state: _,
             }) => Self::FocusOuter,
             Event::Key(KeyEvent {
                 code: KeyCode::Right | KeyCode::Char('l'),
-                modifiers: KeyModifiers::NONE,
+                modifiers: KeyModifiers::NONE | KeyModifiers::CONTROL,
                 kind: KeyEventKind::Press,
                 state: _,
             }) => Self::FocusInner,


### PR DESCRIPTION
After this change the "left arrow" and "h" keypresses will collapse a text
section if it is expanded and currently selected.

This allows users to navigate around a diff more easily since they don't need
to scroll through all of the lines in a section to get to the next section.
Instead, they can just collapse the section quickly and move to the next one.

This fixes one of my only gripes about scm-record compared to the builtin
editor in Mercurial.