### PR TITLE
Fix clippy dead_code error for `IsizeExt` with latest 1.78 stable toolchain

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -19,6 +19,7 @@ impl UsizeExt for usize {
 
 pub trait IsizeExt {
     fn unwrap_usize(self) -> usize;
+    #[allow(dead_code)]
     fn clamp_into_u16(self) -> u16;
     fn clamp_into_usize(self) -> usize;
 }


### PR DESCRIPTION
On 1.78 clippy notices that the `clamp_into_u16` `IsizeExt` trait is dead code. The corresponding function in the `UsizeExt` trait is used however.

This commit tags the `IsizeExt` version with `#[allow(dead_code)]` to silence the clippy error.