### PR TITLE
Fix TestFilesystem::read_dir_diff_paths

### DIFF
--- a/src/scm_diff_editor.rs
+++ b/src/scm_diff_editor.rs
@@ -1088,11 +1088,17 @@ mod tests {
 
     impl Filesystem for TestFilesystem {
         fn read_dir_diff_paths(&self, left: &Path, right: &Path) -> Result<BTreeSet<PathBuf>> {
-            Ok(self
+            let left_files = self
                 .files
                 .keys()
-                .filter(|path| path.starts_with(left) || path.starts_with(right))
-                .cloned()
+                .filter_map(|path| path.strip_prefix(left).ok());
+            let right_files = self
+                .files
+                .keys()
+                .filter_map(|path| path.strip_prefix(right).ok());
+            Ok(left_files
+                .chain(right_files)
+                .map(|path| path.to_path_buf())
                 .collect())
         }
 


### PR DESCRIPTION
This function collects the files present in the `left` and `right` directories. It should return the path suffix with the `left` and `right` prefix stripped. This is necessary because `process_opts` will add the `left` and `right` prefix back to the paths returned by `read_dir_diff_paths`. If we don't strip the prefix, we will end up with invalid paths where the prefix is duplicated.

This went unnoticed since the current tests don't diff directories. I will add a test that diffs directories in a subsequent commit.