### PR TITLE
Add key bindings to jump to the next item of the same kind

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -189,34 +189,18 @@ impl From<crossterm::event::Event> for Event {
                 modifiers: _,
             }) => Self::ScrollDown,
 
-            Event::Key(
-                KeyEvent {
-                    code: KeyCode::PageUp,
-                    modifiers: KeyModifiers::NONE,
-                    kind: KeyEventKind::Press,
-                    state: _,
-                }
-                | KeyEvent {
-                    code: KeyCode::Char('b'),
-                    modifiers: KeyModifiers::CONTROL,
-                    kind: KeyEventKind::Press,
-                    state: _,
-                },
-            ) => Self::PageUp,
-            Event::Key(
-                KeyEvent {
-                    code: KeyCode::PageDown,
-                    modifiers: KeyModifiers::NONE,
-                    kind: KeyEventKind::Press,
-                    state: _,
-                }
-                | KeyEvent {
-                    code: KeyCode::Char('f'),
-                    modifiers: KeyModifiers::CONTROL,
-                    kind: KeyEventKind::Press,
-                    state: _,
-                },
-            ) => Self::PageDown,
+            Event::Key(KeyEvent {
+                code: KeyCode::PageUp | KeyCode::Char('b'),
+                modifiers: KeyModifiers::CONTROL,
+                kind: KeyEventKind::Press,
+                state: _,
+            }) => Self::PageUp,
+            Event::Key(KeyEvent {
+                code: KeyCode::PageDown | KeyCode::Char('f'),
+                modifiers: KeyModifiers::CONTROL,
+                kind: KeyEventKind::Press,
+                state: _,
+            }) => Self::PageDown,
 
             Event::Key(KeyEvent {
                 code: KeyCode::Up | KeyCode::Char('k'),
@@ -776,11 +760,11 @@ impl<'state, 'input> Recorder<'state, 'input> {
                             event: Event::ScrollDown,
                         },
                         MenuItem {
-                            label: Cow::Borrowed("Page up (page-up, ctrl-b)"),
+                            label: Cow::Borrowed("Previous page (ctrl-page-up, ctrl-b)"),
                             event: Event::PageUp,
                         },
                         MenuItem {
-                            label: Cow::Borrowed("Page down (page-down, ctrl-f)"),
+                            label: Cow::Borrowed("Next page (ctrl-page-down, ctrl-f)"),
                             event: Event::PageDown,
                         },
                     ],

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -165,7 +165,7 @@ impl From<crossterm::event::Event> for Event {
             }) => Self::QuitAccept,
 
             Event::Key(KeyEvent {
-                code: KeyCode::Char('y'),
+                code: KeyCode::Up | KeyCode::Char('y'),
                 modifiers: KeyModifiers::CONTROL,
                 kind: KeyEventKind::Press,
                 state: _,
@@ -177,7 +177,7 @@ impl From<crossterm::event::Event> for Event {
                 modifiers: _,
             }) => Self::ScrollUp,
             Event::Key(KeyEvent {
-                code: KeyCode::Char('e'),
+                code: KeyCode::Down | KeyCode::Char('e'),
                 modifiers: KeyModifiers::CONTROL,
                 kind: KeyEventKind::Press,
                 state: _,
@@ -752,11 +752,11 @@ impl<'state, 'input> Recorder<'state, 'input> {
                             event: Event::ExpandAll,
                         },
                         MenuItem {
-                            label: Cow::Borrowed("Scroll up (ctrl-y)"),
+                            label: Cow::Borrowed("Scroll up (ctrl-up, ctrl-y)"),
                             event: Event::ScrollUp,
                         },
                         MenuItem {
-                            label: Cow::Borrowed("Scroll down (ctrl-e)"),
+                            label: Cow::Borrowed("Scroll down (ctrl-down, ctrl-e)"),
                             event: Event::ScrollDown,
                         },
                         MenuItem {


### PR DESCRIPTION
This PR does a few things:

1. The keybindings for scroll up and scroll down are changed. After this PR the only bindings for this movement are ctrl-up and ctrl-down
2. The keybindings for page up and page down (viewport) are changed. After this PR the only bindings for this movement are ctrl-page-up and ctrl-page-down.
3. It adds new keybindings (page-up and page-down) to jump to the next item with the same type as the current item. For example, if the user is on a section header, page-down will jump to the next section header. If the user is on an editable line, page down will jump to the next editable line.

This works well, but probably needs a little bit of polish before submission. Hopefully this can unblock https://github.com/arxanas/scm-record/pull/39 which allows the user to collapse sections using the "focus outward" keybindings (i.e. the left arrow key).