### PR TITLE
Adjust get_selected_contents behavior

### DIFF
--- a/scm-record/src/types.rs
+++ b/scm-record/src/types.rs
@@ -279,7 +279,7 @@ impl File<'_> {
             file_mode,
             sections,
         } = self;
-        let mut acc_selected = if file_mode == &None || file_mode == &Some(FileMode::absent()) {
+        let mut acc_selected = if file_mode.is_none() || file_mode == &Some(FileMode::absent()) {
             SelectedContents::Absent
         } else {
             SelectedContents::Unchanged

--- a/scm-record/tests/test_scm_record.rs
+++ b/scm-record/tests/test_scm_record.rs
@@ -1198,7 +1198,7 @@ fn test_state_binary_selected_contents() -> TestResult {
     // the UI to never allow selecting both).
     assert_snapshot!(test(false, true), @r###"(Binary { old_description: Some("abc123 (123 bytes)"), new_description: Some("def456 (456 bytes)") }, Unchanged)"###);
 
-    assert_snapshot!(test(true, true), @r###"(Binary { old_description: Some("abc123 (123 bytes)"), new_description: Some("def456 (456 bytes)") }, Unchanged)"###);
+    assert_snapshot!(test(true, true), @r###"(Binary { old_description: Some("abc123 (123 bytes)"), new_description: Some("def456 (456 bytes)") }, Present { contents: "foo\n" })"###);
 
     Ok(())
 }


### PR DESCRIPTION
Draft PR to enable the fix for [jj #3702](https://github.com/martinvonz/jj/issues/3702) and [jj #3846](https://github.com/martinvonz/jj/issues/3846) in [jj #4078](https://github.com/martinvonz/jj/pull/4078).

The logic in `get_selected_contents` generally seems really confusing to me and these changes probably don't help mitigating that. From what I can tell, it doesn't break existing tests though, neither in this repo, nor in [`jj`](https://github.com/martinvonz/jj) (in combination with [jj #4078](https://github.com/martinvonz/jj/pull/4078)).

The main problems seem to be:
1. **The general structure of `get_selected_contents`**
  Going through the sections one-by-one makes it hard to differentiate between `Absent` and `Unchanged` `SelectedContents`.
2. **The way `scm-record` handles (doesn't handle) file mode changes**
  I feel like the client shouldn't be responsible for manually adding FileMode sections at all. Ideally this part wouldn't be exposed at all, but just be handled by `scm-record` internally.
