### PR TITLE
Expect all file mode transitions to be represented by FileMode sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- BREAKING (#93): File mode changes (including file creation and file deletion) should now always be represented as `Section::FileMode`.
+
 ## [0.5.0] - 2025-01-10
 
 ### Changed

--- a/scm-diff-editor/src/render.rs
+++ b/scm-diff-editor/src/render.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::path::PathBuf;
 
 use scm_record::helpers::make_binary_description;
-use scm_record::{ChangeType, File, FileMode, Section, SectionChangedLine};
+use scm_record::{ChangeType, File, Section, SectionChangedLine};
 use tracing::warn;
 
 use super::{Error, FileContents, FileInfo, Filesystem};
@@ -38,14 +38,10 @@ pub fn create_file(
     } = filesystem.read_file_info(&right_path)?;
     let mut sections = Vec::new();
 
-    if left_file_mode != right_file_mode
-        && left_file_mode != FileMode::absent()
-        && right_file_mode != FileMode::absent()
-    {
+    if left_file_mode != right_file_mode {
         sections.push(Section::FileMode {
             is_checked: false,
-            before: left_file_mode,
-            after: right_file_mode,
+            mode: right_file_mode,
         });
     }
 
@@ -143,7 +139,7 @@ pub fn create_file(
             None
         },
         path: Cow::Owned(right_display_path),
-        file_mode: None, // TODO
+        file_mode: left_file_mode,
         sections,
     })
 }
@@ -156,7 +152,7 @@ pub fn create_merge_file(
     output_path: PathBuf,
 ) -> Result<File<'static>, Error> {
     let FileInfo {
-        file_mode: _,
+        file_mode: left_file_mode,
         contents: left_contents,
     } = filesystem.read_file_info(&left_path)?;
     let FileInfo {
@@ -211,7 +207,7 @@ pub fn create_merge_file(
     Ok(File {
         old_path: Some(Cow::Owned(base_path)),
         path: Cow::Owned(output_path),
-        file_mode: None,
+        file_mode: left_file_mode,
         sections,
     })
 }

--- a/scm-diff-editor/src/testing.rs
+++ b/scm-diff-editor/src/testing.rs
@@ -60,7 +60,7 @@ impl Filesystem for TestFilesystem {
                     source: io::Error::new(io::ErrorKind::Other, "is a directory"),
                 }),
                 None => Ok(FileInfo {
-                    file_mode: FileMode::absent(),
+                    file_mode: FileMode::Absent,
                     contents: FileContents::Absent,
                 }),
             },
@@ -97,7 +97,7 @@ pub fn file_info(contents: impl Into<String>) -> FileInfo {
     let contents = contents.into();
     let num_bytes = contents.len().try_into().unwrap();
     FileInfo {
-        file_mode: FileMode(0o100644),
+        file_mode: FileMode::Unix(0o100644),
         contents: FileContents::Text {
             contents,
             hash: "abc123".to_string(),

--- a/scm-diff-editor/tests/test_scm_diff_editor.rs
+++ b/scm-diff-editor/tests/test_scm_diff_editor.rs
@@ -39,52 +39,54 @@ qux2
         },
     )?;
     assert_debug_snapshot!(files, @r###"
-        [
-            File {
-                old_path: Some(
-                    "left",
-                ),
-                path: "right",
-                file_mode: None,
-                sections: [
-                    Changed {
-                        lines: [
-                            SectionChangedLine {
-                                is_checked: false,
-                                change_type: Removed,
-                                line: "foo\n",
-                            },
-                            SectionChangedLine {
-                                is_checked: false,
-                                change_type: Added,
-                                line: "qux1\n",
-                            },
-                        ],
-                    },
-                    Unchanged {
-                        lines: [
-                            "common1\n",
-                            "common2\n",
-                        ],
-                    },
-                    Changed {
-                        lines: [
-                            SectionChangedLine {
-                                is_checked: false,
-                                change_type: Removed,
-                                line: "bar\n",
-                            },
-                            SectionChangedLine {
-                                is_checked: false,
-                                change_type: Added,
-                                line: "qux2\n",
-                            },
-                        ],
-                    },
-                ],
-            },
-        ]
-        "###);
+    [
+        File {
+            old_path: Some(
+                "left",
+            ),
+            path: "right",
+            file_mode: Unix(
+                33188,
+            ),
+            sections: [
+                Changed {
+                    lines: [
+                        SectionChangedLine {
+                            is_checked: false,
+                            change_type: Removed,
+                            line: "foo\n",
+                        },
+                        SectionChangedLine {
+                            is_checked: false,
+                            change_type: Added,
+                            line: "qux1\n",
+                        },
+                    ],
+                },
+                Unchanged {
+                    lines: [
+                        "common1\n",
+                        "common2\n",
+                    ],
+                },
+                Changed {
+                    lines: [
+                        SectionChangedLine {
+                            is_checked: false,
+                            change_type: Removed,
+                            line: "bar\n",
+                        },
+                        SectionChangedLine {
+                            is_checked: false,
+                            change_type: Added,
+                            line: "qux2\n",
+                        },
+                    ],
+                },
+            ],
+        },
+    ]
+    "###);
 
     select_all(&mut files);
     apply_changes(
@@ -97,34 +99,34 @@ qux2
         },
     )?;
     insta::assert_debug_snapshot!(filesystem, @r###"
-        TestFilesystem {
-            files: {
-                "left": FileInfo {
-                    file_mode: FileMode(
-                        33188,
-                    ),
-                    contents: Text {
-                        contents: "foo\ncommon1\ncommon2\nbar\n",
-                        hash: "abc123",
-                        num_bytes: 24,
-                    },
-                },
-                "right": FileInfo {
-                    file_mode: FileMode(
-                        33188,
-                    ),
-                    contents: Text {
-                        contents: "qux1\ncommon1\ncommon2\nqux2\n",
-                        hash: "abc123",
-                        num_bytes: 26,
-                    },
+    TestFilesystem {
+        files: {
+            "left": FileInfo {
+                file_mode: Unix(
+                    33188,
+                ),
+                contents: Text {
+                    contents: "foo\ncommon1\ncommon2\nbar\n",
+                    hash: "abc123",
+                    num_bytes: 24,
                 },
             },
-            dirs: {
-                "",
+            "right": FileInfo {
+                file_mode: Unix(
+                    33188,
+                ),
+                contents: Text {
+                    contents: "qux1\ncommon1\ncommon2\nqux2\n",
+                    hash: "abc123",
+                    num_bytes: 26,
+                },
             },
-        }
-        "###);
+        },
+        dirs: {
+            "",
+        },
+    }
+    "###);
 
     Ok(())
 }
@@ -168,34 +170,34 @@ qux2
         },
     )?;
     insta::assert_debug_snapshot!(filesystem, @r###"
-        TestFilesystem {
-            files: {
-                "left": FileInfo {
-                    file_mode: FileMode(
-                        33188,
-                    ),
-                    contents: Text {
-                        contents: "foo\ncommon1\ncommon2\nbar\n",
-                        hash: "abc123",
-                        num_bytes: 24,
-                    },
-                },
-                "right": FileInfo {
-                    file_mode: FileMode(
-                        33188,
-                    ),
-                    contents: Text {
-                        contents: "foo\ncommon1\ncommon2\nbar\n",
-                        hash: "abc123",
-                        num_bytes: 24,
-                    },
+    TestFilesystem {
+        files: {
+            "left": FileInfo {
+                file_mode: Unix(
+                    33188,
+                ),
+                contents: Text {
+                    contents: "foo\ncommon1\ncommon2\nbar\n",
+                    hash: "abc123",
+                    num_bytes: 24,
                 },
             },
-            dirs: {
-                "",
+            "right": FileInfo {
+                file_mode: Unix(
+                    33188,
+                ),
+                contents: Text {
+                    contents: "foo\ncommon1\ncommon2\nbar\n",
+                    hash: "abc123",
+                    num_bytes: 24,
+                },
             },
-        }
-        "###);
+        },
+        dirs: {
+            "",
+        },
+    }
+    "###);
 
     Ok(())
 }
@@ -221,27 +223,33 @@ fn test_diff_absent_left() -> Result<()> {
         },
     )?;
     assert_debug_snapshot!(files, @r###"
-        [
-            File {
-                old_path: Some(
-                    "left",
-                ),
-                path: "right",
-                file_mode: None,
-                sections: [
-                    Changed {
-                        lines: [
-                            SectionChangedLine {
-                                is_checked: false,
-                                change_type: Added,
-                                line: "right\n",
-                            },
-                        ],
-                    },
-                ],
-            },
-        ]
-        "###);
+    [
+        File {
+            old_path: Some(
+                "left",
+            ),
+            path: "right",
+            file_mode: Absent,
+            sections: [
+                FileMode {
+                    is_checked: false,
+                    mode: Unix(
+                        33188,
+                    ),
+                },
+                Changed {
+                    lines: [
+                        SectionChangedLine {
+                            is_checked: false,
+                            change_type: Added,
+                            line: "right\n",
+                        },
+                    ],
+                },
+            ],
+        },
+    ]
+    "###);
 
     select_all(&mut files);
     apply_changes(
@@ -254,24 +262,24 @@ fn test_diff_absent_left() -> Result<()> {
         },
     )?;
     insta::assert_debug_snapshot!(filesystem, @r###"
-        TestFilesystem {
-            files: {
-                "right": FileInfo {
-                    file_mode: FileMode(
-                        33188,
-                    ),
-                    contents: Text {
-                        contents: "right\n",
-                        hash: "abc123",
-                        num_bytes: 6,
-                    },
+    TestFilesystem {
+        files: {
+            "right": FileInfo {
+                file_mode: Unix(
+                    33188,
+                ),
+                contents: Text {
+                    contents: "right\n",
+                    hash: "abc123",
+                    num_bytes: 6,
                 },
             },
-            dirs: {
-                "",
-            },
-        }
-        "###);
+        },
+        dirs: {
+            "",
+        },
+    }
+    "###);
 
     Ok(())
 }
@@ -297,27 +305,33 @@ fn test_diff_absent_right() -> Result<()> {
         },
     )?;
     assert_debug_snapshot!(files, @r###"
-        [
-            File {
-                old_path: Some(
-                    "left",
-                ),
-                path: "right",
-                file_mode: None,
-                sections: [
-                    Changed {
-                        lines: [
-                            SectionChangedLine {
-                                is_checked: false,
-                                change_type: Removed,
-                                line: "left\n",
-                            },
-                        ],
-                    },
-                ],
-            },
-        ]
-        "###);
+    [
+        File {
+            old_path: Some(
+                "left",
+            ),
+            path: "right",
+            file_mode: Unix(
+                33188,
+            ),
+            sections: [
+                FileMode {
+                    is_checked: false,
+                    mode: Absent,
+                },
+                Changed {
+                    lines: [
+                        SectionChangedLine {
+                            is_checked: false,
+                            change_type: Removed,
+                            line: "left\n",
+                        },
+                    ],
+                },
+            ],
+        },
+    ]
+    "###);
 
     select_all(&mut files);
     apply_changes(
@@ -330,24 +344,24 @@ fn test_diff_absent_right() -> Result<()> {
         },
     )?;
     insta::assert_debug_snapshot!(filesystem, @r###"
-        TestFilesystem {
-            files: {
-                "left": FileInfo {
-                    file_mode: FileMode(
-                        33188,
-                    ),
-                    contents: Text {
-                        contents: "left\n",
-                        hash: "abc123",
-                        num_bytes: 5,
-                    },
+    TestFilesystem {
+        files: {
+            "left": FileInfo {
+                file_mode: Unix(
+                    33188,
+                ),
+                contents: Text {
+                    contents: "left\n",
+                    hash: "abc123",
+                    num_bytes: 5,
                 },
             },
-            dirs: {
-                "",
-            },
-        }
-        "###);
+        },
+        dirs: {
+            "",
+        },
+    }
+    "###);
 
     Ok(())
 }
@@ -415,36 +429,36 @@ fn test_diff_files_in_subdirectories() -> Result<()> {
         },
     )?;
     assert_debug_snapshot!(filesystem, @r###"
-        TestFilesystem {
-            files: {
-                "left/foo": FileInfo {
-                    file_mode: FileMode(
-                        33188,
-                    ),
-                    contents: Text {
-                        contents: "left contents\n",
-                        hash: "abc123",
-                        num_bytes: 14,
-                    },
-                },
-                "right/foo": FileInfo {
-                    file_mode: FileMode(
-                        33188,
-                    ),
-                    contents: Text {
-                        contents: "left contents\n",
-                        hash: "abc123",
-                        num_bytes: 14,
-                    },
+    TestFilesystem {
+        files: {
+            "left/foo": FileInfo {
+                file_mode: Unix(
+                    33188,
+                ),
+                contents: Text {
+                    contents: "left contents\n",
+                    hash: "abc123",
+                    num_bytes: 14,
                 },
             },
-            dirs: {
-                "",
-                "left",
-                "right",
+            "right/foo": FileInfo {
+                file_mode: Unix(
+                    33188,
+                ),
+                contents: Text {
+                    contents: "left contents\n",
+                    hash: "abc123",
+                    num_bytes: 14,
+                },
             },
-        }
-        "###);
+        },
+        dirs: {
+            "",
+            "left",
+            "right",
+        },
+    }
+    "###);
 
     Ok(())
 }
@@ -479,36 +493,36 @@ fn test_dir_diff_no_changes() -> Result<()> {
         },
     )?;
     assert_debug_snapshot!(filesystem, @r###"
-        TestFilesystem {
-            files: {
-                "left/foo": FileInfo {
-                    file_mode: FileMode(
-                        33188,
-                    ),
-                    contents: Text {
-                        contents: "left contents\n",
-                        hash: "abc123",
-                        num_bytes: 14,
-                    },
-                },
-                "right/foo": FileInfo {
-                    file_mode: FileMode(
-                        33188,
-                    ),
-                    contents: Text {
-                        contents: "left contents\n",
-                        hash: "abc123",
-                        num_bytes: 14,
-                    },
+    TestFilesystem {
+        files: {
+            "left/foo": FileInfo {
+                file_mode: Unix(
+                    33188,
+                ),
+                contents: Text {
+                    contents: "left contents\n",
+                    hash: "abc123",
+                    num_bytes: 14,
                 },
             },
-            dirs: {
-                "",
-                "left",
-                "right",
+            "right/foo": FileInfo {
+                file_mode: Unix(
+                    33188,
+                ),
+                contents: Text {
+                    contents: "left contents\n",
+                    hash: "abc123",
+                    num_bytes: 14,
+                },
             },
-        }
-        "###);
+        },
+        dirs: {
+            "",
+            "left",
+            "right",
+        },
+    }
+    "###);
 
     Ok(())
 }
@@ -555,48 +569,50 @@ Hello world 4
         },
     )?;
     insta::assert_debug_snapshot!(files, @r###"
-        [
-            File {
-                old_path: Some(
-                    "base",
-                ),
-                path: "output",
-                file_mode: None,
-                sections: [
-                    Unchanged {
-                        lines: [
-                            "Hello world 1\n",
-                            "Hello world 2\n",
-                        ],
-                    },
-                    Changed {
-                        lines: [
-                            SectionChangedLine {
-                                is_checked: false,
-                                change_type: Added,
-                                line: "Hello world L\n",
-                            },
-                            SectionChangedLine {
-                                is_checked: false,
-                                change_type: Removed,
-                                line: "Hello world 3\n",
-                            },
-                            SectionChangedLine {
-                                is_checked: false,
-                                change_type: Added,
-                                line: "Hello world R\n",
-                            },
-                        ],
-                    },
-                    Unchanged {
-                        lines: [
-                            "Hello world 4\n",
-                        ],
-                    },
-                ],
-            },
-        ]
-        "###);
+    [
+        File {
+            old_path: Some(
+                "base",
+            ),
+            path: "output",
+            file_mode: Unix(
+                33188,
+            ),
+            sections: [
+                Unchanged {
+                    lines: [
+                        "Hello world 1\n",
+                        "Hello world 2\n",
+                    ],
+                },
+                Changed {
+                    lines: [
+                        SectionChangedLine {
+                            is_checked: false,
+                            change_type: Added,
+                            line: "Hello world L\n",
+                        },
+                        SectionChangedLine {
+                            is_checked: false,
+                            change_type: Removed,
+                            line: "Hello world 3\n",
+                        },
+                        SectionChangedLine {
+                            is_checked: false,
+                            change_type: Added,
+                            line: "Hello world R\n",
+                        },
+                    ],
+                },
+                Unchanged {
+                    lines: [
+                        "Hello world 4\n",
+                    ],
+                },
+            ],
+        },
+    ]
+    "###);
 
     select_all(&mut files);
     apply_changes(
@@ -610,54 +626,54 @@ Hello world 4
     )?;
 
     assert_debug_snapshot!(filesystem, @r###"
-        TestFilesystem {
-            files: {
-                "base": FileInfo {
-                    file_mode: FileMode(
-                        33188,
-                    ),
-                    contents: Text {
-                        contents: "Hello world 1\nHello world 2\nHello world 3\nHello world 4\n",
-                        hash: "abc123",
-                        num_bytes: 56,
-                    },
-                },
-                "left": FileInfo {
-                    file_mode: FileMode(
-                        33188,
-                    ),
-                    contents: Text {
-                        contents: "Hello world 1\nHello world 2\nHello world L\nHello world 4\n",
-                        hash: "abc123",
-                        num_bytes: 56,
-                    },
-                },
-                "output": FileInfo {
-                    file_mode: FileMode(
-                        33188,
-                    ),
-                    contents: Text {
-                        contents: "Hello world 1\nHello world 2\nHello world L\nHello world R\nHello world 4\n",
-                        hash: "abc123",
-                        num_bytes: 70,
-                    },
-                },
-                "right": FileInfo {
-                    file_mode: FileMode(
-                        33188,
-                    ),
-                    contents: Text {
-                        contents: "Hello world 1\nHello world 2\nHello world R\nHello world 4\n",
-                        hash: "abc123",
-                        num_bytes: 56,
-                    },
+    TestFilesystem {
+        files: {
+            "base": FileInfo {
+                file_mode: Unix(
+                    33188,
+                ),
+                contents: Text {
+                    contents: "Hello world 1\nHello world 2\nHello world 3\nHello world 4\n",
+                    hash: "abc123",
+                    num_bytes: 56,
                 },
             },
-            dirs: {
-                "",
+            "left": FileInfo {
+                file_mode: Unix(
+                    33188,
+                ),
+                contents: Text {
+                    contents: "Hello world 1\nHello world 2\nHello world L\nHello world 4\n",
+                    hash: "abc123",
+                    num_bytes: 56,
+                },
             },
-        }
-        "###);
+            "output": FileInfo {
+                file_mode: Unix(
+                    33188,
+                ),
+                contents: Text {
+                    contents: "Hello world 1\nHello world 2\nHello world L\nHello world R\nHello world 4\n",
+                    hash: "abc123",
+                    num_bytes: 70,
+                },
+            },
+            "right": FileInfo {
+                file_mode: Unix(
+                    33188,
+                ),
+                contents: Text {
+                    contents: "Hello world 1\nHello world 2\nHello world R\nHello world 4\n",
+                    hash: "abc123",
+                    num_bytes: 56,
+                },
+            },
+        },
+        dirs: {
+            "",
+        },
+    }
+    "###);
 
     Ok(())
 }
@@ -688,32 +704,38 @@ Hello world 2
         },
     )?;
     insta::assert_debug_snapshot!(files, @r###"
-        [
-            File {
-                old_path: Some(
-                    "left",
-                ),
-                path: "right",
-                file_mode: None,
-                sections: [
-                    Changed {
-                        lines: [
-                            SectionChangedLine {
-                                is_checked: false,
-                                change_type: Added,
-                                line: "Hello world 1\n",
-                            },
-                            SectionChangedLine {
-                                is_checked: false,
-                                change_type: Added,
-                                line: "Hello world 2\n",
-                            },
-                        ],
-                    },
-                ],
-            },
-        ]
-        "###);
+    [
+        File {
+            old_path: Some(
+                "left",
+            ),
+            path: "right",
+            file_mode: Absent,
+            sections: [
+                FileMode {
+                    is_checked: false,
+                    mode: Unix(
+                        33188,
+                    ),
+                },
+                Changed {
+                    lines: [
+                        SectionChangedLine {
+                            is_checked: false,
+                            change_type: Added,
+                            line: "Hello world 1\n",
+                        },
+                        SectionChangedLine {
+                            is_checked: false,
+                            change_type: Added,
+                            line: "Hello world 2\n",
+                        },
+                    ],
+                },
+            ],
+        },
+    ]
+    "###);
 
     // Select no changes from new file.
     apply_changes(
@@ -726,13 +748,13 @@ Hello world 2
         },
     )?;
     insta::assert_debug_snapshot!(filesystem, @r###"
-        TestFilesystem {
-            files: {},
-            dirs: {
-                "",
-            },
-        }
-        "###);
+    TestFilesystem {
+        files: {},
+        dirs: {
+            "",
+        },
+    }
+    "###);
 
     // Select all changes from new file.
     select_all(&mut files);
@@ -746,27 +768,27 @@ Hello world 2
         },
     )?;
     insta::assert_debug_snapshot!(filesystem, @r###"
-        TestFilesystem {
-            files: {
-                "right": FileInfo {
-                    file_mode: FileMode(
-                        33188,
-                    ),
-                    contents: Text {
-                        contents: "Hello world 1\nHello world 2\n",
-                        hash: "abc123",
-                        num_bytes: 28,
-                    },
+    TestFilesystem {
+        files: {
+            "right": FileInfo {
+                file_mode: Unix(
+                    33188,
+                ),
+                contents: Text {
+                    contents: "Hello world 1\nHello world 2\n",
+                    hash: "abc123",
+                    num_bytes: 28,
                 },
             },
-            dirs: {
-                "",
-            },
-        }
-        "###);
+        },
+        dirs: {
+            "",
+        },
+    }
+    "###);
 
     // Select only some changes from new file.
-    match files[0].sections.get_mut(0).unwrap() {
+    match files[0].sections.get_mut(1).unwrap() {
         Section::Changed { ref mut lines } => lines[0].is_checked = false,
         _ => panic!("Expected changed section"),
     }
@@ -780,24 +802,24 @@ Hello world 2
         },
     )?;
     insta::assert_debug_snapshot!(filesystem, @r###"
-        TestFilesystem {
-            files: {
-                "right": FileInfo {
-                    file_mode: FileMode(
-                        33188,
-                    ),
-                    contents: Text {
-                        contents: "Hello world 2\n",
-                        hash: "abc123",
-                        num_bytes: 14,
-                    },
+    TestFilesystem {
+        files: {
+            "right": FileInfo {
+                file_mode: Unix(
+                    33188,
+                ),
+                contents: Text {
+                    contents: "Hello world 2\n",
+                    hash: "abc123",
+                    num_bytes: 14,
                 },
             },
-            dirs: {
-                "",
-            },
-        }
-        "###);
+        },
+        dirs: {
+            "",
+        },
+    }
+    "###);
 
     Ok(())
 }

--- a/scm-record/benches/benches.rs
+++ b/scm-record/benches/benches.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, path::Path};
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 
 use scm_record::{
-    helpers::TestingInput, ChangeType, Event, File, RecordState, Recorder, Section,
+    helpers::TestingInput, ChangeType, Event, File, FileMode, RecordState, Recorder, Section,
     SectionChangedLine,
 };
 
@@ -25,7 +25,7 @@ fn bench_record(c: &mut Criterion) {
             files: vec![File {
                 old_path: None,
                 path: Cow::Borrowed(Path::new("foo")),
-                file_mode: None,
+                file_mode: FileMode::FILE_DEFAULT,
                 sections: vec![Section::Changed {
                     lines: [vec![before_line; 1000], vec![after_line; 1000]].concat(),
                 }],

--- a/scm-record/src/lib.rs
+++ b/scm-record/src/lib.rs
@@ -18,6 +18,6 @@ pub mod consts;
 pub mod helpers;
 pub use types::{
     ChangeType, Commit, File, FileMode, RecordError, RecordState, Section, SectionChangedLine,
-    SelectedContents,
+    SelectedChanges, SelectedContents,
 };
 pub use ui::{Event, RecordInput, Recorder, TerminalKind, TestingScreenshot};

--- a/scm-record/tests/example_contents.json
+++ b/scm-record/tests/example_contents.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "foo/bar",
-      "file_mode": null,
+      "file_mode": { "Unix": 33188 },
       "sections": [
         {
           "Unchanged": {
@@ -67,7 +67,7 @@
     },
     {
       "path": "baz",
-      "file_mode": null,
+      "file_mode": { "Unix": 33188 },
       "sections": [
         {
           "Unchanged": {


### PR DESCRIPTION
An alternative approach to https://github.com/arxanas/scm-record/pull/92 for fixing various issues in `jj`.

Based on a discussion from Discord where it was decided that `scm-record` should expect that any file mode transitions have a `Section::FileMode`. This PR also implements UI/UX improvements in `scm-record` such as auto-unselecting the file deletion mode transition if any of the deleted lines are un-selected, but that could be done as a follow-up if the approach works out.

See https://github.com/arxanas/scm-record/pull/92#issuecomment-2616407595 for some rationale regarding the removal of `SelectedContents::Absent`, `.get_file_mode()` and the introduction of `SelectedChanges`.

Note also that the internal consumers of `.get_selected_changes()` are not yet finished - for example, `apply_changes` is not completely passing the tests yet. If there's agreement on the approach then I can update these too.

Fixes #26