### PR TITLE
Improve UX for interaction between changes and mode transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - BREAKING (#93): File mode changes (including file creation and file deletion) should now always be represented as `Section::FileMode`.
+- (#95) Some selections/deselections are now performed automatically to prevent impossible combinations (like trying to delete a file but leave lines in it)
 
 ## [0.5.0] - 2025-01-10
 

--- a/scm-record/src/ui.rs
+++ b/scm-record/src/ui.rs
@@ -453,6 +453,13 @@ enum CommitViewMode {
     Adjacent,
 }
 
+#[allow(clippy::enum_variant_names)]
+enum ToggleSideEffects {
+    ToggledModeChangeSection(SectionKey, FileMode, FileMode, bool),
+    ToggledChangedSection(SectionKey, bool),
+    ToggledChangedLine(LineKey, bool),
+}
+
 /// UI component to record the user's changes.
 pub struct Recorder<'state, 'input> {
     state: RecordState<'state>,
@@ -1807,8 +1814,8 @@ impl<'state, 'input> Recorder<'state, 'input> {
             return Ok(());
         }
 
-        match selection {
-            SelectionKey::None => {}
+        let side_effects = match selection {
+            SelectionKey::None => None,
             SelectionKey::File(file_key) => {
                 let tristate = self.file_tristate(file_key)?;
                 let is_checked_new = match tristate {
@@ -1818,6 +1825,8 @@ impl<'state, 'input> Recorder<'state, 'input> {
                 self.visit_file(file_key, |file| {
                     file.set_checked(is_checked_new);
                 })?;
+
+                None
             }
             SelectionKey::Section(section_key) => {
                 let tristate = self.section_tristate(section_key)?;
@@ -1826,16 +1835,109 @@ impl<'state, 'input> Recorder<'state, 'input> {
                     Tristate::Partial | Tristate::True => false,
                 };
 
+                let old_file_mode = self.visit_file_for_section(section_key, |f| f.file_mode)?;
+
                 self.visit_section(section_key, |section| {
                     section.set_checked(is_checked_new);
-                })?;
+
+                    if let Section::FileMode { mode, .. } = section {
+                        return Some(ToggleSideEffects::ToggledModeChangeSection(
+                            section_key,
+                            old_file_mode,
+                            *mode,
+                            is_checked_new,
+                        ));
+                    }
+
+                    if let Section::Changed { .. } = section {
+                        return Some(ToggleSideEffects::ToggledChangedSection(
+                            section_key,
+                            is_checked_new,
+                        ));
+                    }
+
+                    None
+                })?
             }
-            SelectionKey::Line(line_key) => {
-                self.visit_line(line_key, |line| {
-                    line.is_checked = !line.is_checked;
-                })?;
+            SelectionKey::Line(line_key) => self.visit_line(line_key, |line| {
+                line.is_checked = !line.is_checked;
+
+                Some(ToggleSideEffects::ToggledChangedLine(
+                    line_key,
+                    line.is_checked,
+                ))
+            })?,
+        };
+
+        if let Some(side_effects) = side_effects {
+            match side_effects {
+                ToggleSideEffects::ToggledModeChangeSection(
+                    section_key,
+                    old_mode,
+                    new_mode,
+                    toggled_to,
+                ) => {
+                    // If we check a deletion, all lines in the file must be deleted
+                    if toggled_to && new_mode == FileMode::Absent {
+                        self.visit_file_for_section(section_key, |file| {
+                            for section in &mut file.sections {
+                                if matches!(section, Section::Changed { .. }) {
+                                    section.set_checked(true);
+                                }
+                            }
+                        })?;
+                    }
+
+                    // If we uncheck a creation, no lines in the file can be added
+                    if !toggled_to && old_mode == FileMode::Absent {
+                        self.visit_file_for_section(section_key, |file| {
+                            for section in &mut file.sections {
+                                section.set_checked(false);
+                            }
+                        })?;
+                    }
+                }
+                ToggleSideEffects::ToggledChangedSection(section_key, toggled_to) => {
+                    self.visit_file_for_section(section_key, |file| {
+                        for section in &mut file.sections {
+                            if let Section::FileMode { mode, is_checked } = section {
+                                // If we removed a line and the file was being deleted, it can no longer
+                                // be deleted as it needs to contain that line
+                                if !toggled_to && *mode == FileMode::Absent {
+                                    *is_checked = false;
+                                }
+
+                                // If we added a line and the file was not being created, it must be created
+                                // in order to contain that line
+                                if toggled_to && file.file_mode == FileMode::Absent {
+                                    *is_checked = true;
+                                }
+                            }
+                        }
+                    })?;
+                }
+                ToggleSideEffects::ToggledChangedLine(line_key, toggled_to) => {
+                    self.visit_file_for_line(line_key, |file| {
+                        for section in &mut file.sections {
+                            if let Section::FileMode { mode, is_checked } = section {
+                                // If we removed a line and the file was being deleted, it can no longer
+                                // be deleted as it needs to contain that line
+                                if !toggled_to && *mode == FileMode::Absent {
+                                    *is_checked = false;
+                                }
+
+                                // If we added a line and the file was not being created, it must be created
+                                // in order to contain that line
+                                if toggled_to && file.file_mode == FileMode::Absent {
+                                    *is_checked = true;
+                                }
+                            }
+                        }
+                    })?;
+                }
             }
-        }
+        };
+
         Ok(())
     }
 
@@ -2055,6 +2157,45 @@ impl<'state, 'input> Recorder<'state, 'input> {
         }
     }
 
+    fn visit_file_for_section<T>(
+        &mut self,
+        section_key: SectionKey,
+        f: impl Fn(&mut File) -> T,
+    ) -> Result<T, RecordError> {
+        let SectionKey {
+            commit_idx: _,
+            file_idx,
+            section_idx: _,
+        } = section_key;
+
+        match self.state.files.get_mut(file_idx) {
+            Some(file) => Ok(f(file)),
+            None => Err(RecordError::Bug(format!(
+                "Out-of-bounds file key: {file_idx:?}"
+            ))),
+        }
+    }
+
+    fn visit_file_for_line<T>(
+        &mut self,
+        line_key: LineKey,
+        f: impl Fn(&mut File) -> T,
+    ) -> Result<T, RecordError> {
+        let LineKey {
+            commit_idx: _,
+            file_idx,
+            section_idx: _,
+            line_idx: _,
+        } = line_key;
+
+        match self.state.files.get_mut(file_idx) {
+            Some(file) => Ok(f(file)),
+            None => Err(RecordError::Bug(format!(
+                "Out-of-bounds file key: {file_idx:?}"
+            ))),
+        }
+    }
+
     fn visit_file<T>(
         &mut self,
         file_key: FileKey,
@@ -2147,11 +2288,11 @@ impl<'state, 'input> Recorder<'state, 'input> {
         Ok(section.tristate())
     }
 
-    fn visit_line(
+    fn visit_line<T>(
         &mut self,
         line_key: LineKey,
-        f: impl FnOnce(&mut SectionChangedLine),
-    ) -> Result<(), RecordError> {
+        f: impl FnOnce(&mut SectionChangedLine) -> Option<T>,
+    ) -> Result<Option<T>, RecordError> {
         let LineKey {
             commit_idx: _,
             file_idx,
@@ -2162,12 +2303,11 @@ impl<'state, 'input> Recorder<'state, 'input> {
         match section {
             Section::Changed { lines } => {
                 let line = &mut lines[line_idx];
-                f(line);
-                Ok(())
+                Ok(f(line))
             }
             Section::Unchanged { .. } | Section::FileMode { .. } | Section::Binary { .. } => {
                 // Do nothing.
-                Ok(())
+                Ok(None)
             }
         }
     }


### PR DESCRIPTION
After #93, it's possible to make selections that don't make sense. For example, you can delete a file, select the file deletion, but de-select some of the file's lines - then there's no file to hold those lines. The same applies for selecting lines in a created file without selecting the file creation.

With this change, selections can now imply other selections (or de-selections) - e.g. selecting a file deletion will automatically select all lines in that file, and selecting any lines in a newly created file will also select the file creation mode change.

For reviews - I'm not able to stack this on #93 because the branch is on my fork. But the changes here are in the second commit.