### PR TITLE
Re-export `Tristate` type

### DIFF
--- a/scm-record/src/lib.rs
+++ b/scm-record/src/lib.rs
@@ -18,6 +18,6 @@ pub mod consts;
 pub mod helpers;
 pub use types::{
     ChangeType, Commit, File, FileMode, RecordError, RecordState, Section, SectionChangedLine,
-    SelectedChanges, SelectedContents,
+    SelectedChanges, SelectedContents, Tristate,
 };
 pub use ui::{Event, RecordInput, Recorder, TerminalKind, TestingScreenshot};

--- a/scm-record/src/types.rs
+++ b/scm-record/src/types.rs
@@ -125,10 +125,14 @@ impl TryFrom<i32> for FileMode {
     }
 }
 
+/// The state of the selection.
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum Tristate {
+    /// All elements are not selected.
     False,
+    /// Some elements are selected.
     Partial,
+    /// All elements are selected.
     True,
 }
 


### PR DESCRIPTION
Both `File` and `Section` have `pub fn tristate()` functions that return this type, but there was no way to use the result in downstream crates because it was not re-exported from the private `types` module.

---

I tried to see if there would be a way for clippy to catch this, but it doesn't seem like there is, since apparently this behavior is what enables the sealed trait pattern.