### PR TITLE
Fix shift+h and shift+l

### DIFF
--- a/scm-record/src/ui.rs
+++ b/scm-record/src/ui.rs
@@ -257,7 +257,7 @@ impl From<crossterm::event::Event> for Event {
             }) => Self::FocusNextSameKind,
 
             Event::Key(KeyEvent {
-                code: KeyCode::Left | KeyCode::Char('h'),
+                code: KeyCode::Left | KeyCode::Char('H'),
                 modifiers: KeyModifiers::SHIFT,
                 kind: KeyEventKind::Press,
                 state: _,
@@ -271,7 +271,7 @@ impl From<crossterm::event::Event> for Event {
                 state: _,
             }) => Self::FocusOuter { fold_section: true },
             Event::Key(KeyEvent {
-                code: KeyCode::Right | KeyCode::Char('l'),
+                code: KeyCode::Right | KeyCode::Char('l' | 'L'),
                 // The shift modifier is accepted for continuity with FocusOuter.
                 modifiers: KeyModifiers::NONE | KeyModifiers::SHIFT,
                 kind: KeyEventKind::Press,


### PR DESCRIPTION
`shift+h` and `shift+l` were not working for me as the KeyCode is sent as uppercase. I only included only the uppercase version for `shift+h` as that's how it's done for other "uppercase" keybindings (`shift+a` and `shift+f`).