### PR TITLE
feat: Add K/J keys for Focus{Prev,Next}SameKind

### DIFF
--- a/scm-record/src/ui.rs
+++ b/scm-record/src/ui.rs
@@ -257,6 +257,19 @@ impl From<crossterm::event::Event> for Event {
             }) => Self::FocusNextSameKind,
 
             Event::Key(KeyEvent {
+                code: KeyCode::Char('K'),
+                modifiers: KeyModifiers::SHIFT,
+                kind: KeyEventKind::Press,
+                state: _,
+            }) => Self::FocusPrevSameKind,
+            Event::Key(KeyEvent {
+                code: KeyCode::Char('J'),
+                modifiers: KeyModifiers::SHIFT,
+                kind: KeyEventKind::Press,
+                state: _,
+            }) => Self::FocusNextSameKind,
+
+            Event::Key(KeyEvent {
                 code: KeyCode::Left | KeyCode::Char('h'),
                 modifiers: KeyModifiers::SHIFT,
                 kind: KeyEventKind::Press,


### PR DESCRIPTION
(Disclaimer: I found out about this project because of jj-vcs)

I really like this tool for editing diffs, the only gripe I have with it that even though 90% of all commands are reachable using vim-style keys from the home row, one very common operation, namely jumping to the next/prev item at the same hierarchy level, forces me to leave home row.

This simple patch remedies this adding the analogous K and J key mappings for these operations.