### PR TITLE
Add (optional) status bar where a message can be shown

### DIFF
--- a/scm-diff-editor/src/lib.rs
+++ b/scm-diff-editor/src/lib.rs
@@ -69,6 +69,11 @@ pub struct Opts {
     /// Write the resolved merge conflicts to this file.
     #[clap(short = 'o', long = "output", conflicts_with("dir_diff"))]
     pub output: Option<PathBuf>,
+
+    /// Display a status message at the bottom of the screen to provide context
+    /// or instructions to the user.
+    #[clap(short = 'm', long = "status-message")]
+    pub status_message: Option<String>,
 }
 
 #[derive(Debug, Error)]
@@ -343,6 +348,7 @@ pub fn process_opts(filesystem: &dyn Filesystem, opts: &Opts) -> Result<DiffCont
             output: _,
             read_only: _,
             dry_run: _,
+            status_message: _,
         } => {
             let files = vec![render::create_file(
                 filesystem,
@@ -365,6 +371,7 @@ pub fn process_opts(filesystem: &dyn Filesystem, opts: &Opts) -> Result<DiffCont
             output: _,
             read_only: _,
             dry_run: _,
+            status_message: _,
         } => {
             let display_paths = filesystem.read_dir_diff_paths(left, right)?;
             let mut files = Vec::new();
@@ -391,6 +398,7 @@ pub fn process_opts(filesystem: &dyn Filesystem, opts: &Opts) -> Result<DiffCont
             output: Some(output),
             read_only: _,
             dry_run: _,
+            status_message: _,
         } => {
             let files = vec![render::create_merge_file(
                 filesystem,
@@ -413,6 +421,7 @@ pub fn process_opts(filesystem: &dyn Filesystem, opts: &Opts) -> Result<DiffCont
             output: None,
             read_only: _,
             dry_run: _,
+            status_message: _,
         } => {
             unreachable!("--output is required when --base is provided");
         }
@@ -425,6 +434,7 @@ pub fn process_opts(filesystem: &dyn Filesystem, opts: &Opts) -> Result<DiffCont
             output: _,
             read_only: _,
             dry_run: _,
+            status_message: _,
         } => {
             unimplemented!("--base cannot be used with --dir-diff");
         }
@@ -435,6 +445,7 @@ pub fn process_opts(filesystem: &dyn Filesystem, opts: &Opts) -> Result<DiffCont
 fn print_dry_run(write_root: &Path, state: RecordState) {
     let RecordState {
         is_read_only: _,
+        status_message: _,
         commits: _,
         files,
     } = state;
@@ -502,6 +513,7 @@ pub fn apply_changes(
 ) -> Result<()> {
     let RecordState {
         is_read_only,
+        status_message: _,
         commits: _,
         files,
     } = state;
@@ -555,6 +567,7 @@ pub fn run(opts: Opts) -> Result<()> {
     let DiffContext { files, write_root } = process_opts(&filesystem, &opts)?;
     let state = RecordState {
         is_read_only: opts.read_only,
+        status_message: opts.status_message,
         commits: Default::default(),
         files,
     };
@@ -715,6 +728,7 @@ qux2
                 base: None,
                 output: None,
                 read_only: false,
+                status_message: None,
                 dry_run: false,
             },
         )?;
@@ -774,6 +788,7 @@ qux2
             &write_root,
             RecordState {
                 is_read_only: false,
+                status_message: None,
                 commits: Default::default(),
                 files,
             },
@@ -836,6 +851,7 @@ qux2
                 base: None,
                 output: None,
                 read_only: false,
+                status_message: None,
                 dry_run: false,
             },
         )?;
@@ -845,6 +861,7 @@ qux2
             &write_root,
             RecordState {
                 is_read_only: false,
+                status_message: None,
                 commits: Default::default(),
                 files,
             },
@@ -899,6 +916,7 @@ qux2
                 base: None,
                 output: None,
                 read_only: false,
+                status_message: None,
                 dry_run: false,
             },
         )?;
@@ -937,6 +955,7 @@ qux2
             &write_root,
             RecordState {
                 is_read_only: false,
+                status_message: None,
                 commits: Default::default(),
                 files,
             },
@@ -981,6 +1000,7 @@ qux2
                 base: None,
                 output: None,
                 read_only: false,
+                status_message: None,
                 dry_run: false,
             },
         )?;
@@ -1019,6 +1039,7 @@ qux2
             &write_root,
             RecordState {
                 is_read_only: false,
+                status_message: None,
                 commits: Default::default(),
                 files,
             },
@@ -1061,6 +1082,7 @@ qux2
                 base: None,
                 output: None,
                 read_only: false,
+                status_message: None,
                 dry_run: false,
             },
         );
@@ -1095,6 +1117,7 @@ qux2
                 base: None,
                 output: None,
                 read_only: false,
+                status_message: None,
                 dry_run: false,
             },
         )?;
@@ -1104,6 +1127,7 @@ qux2
             &write_root,
             RecordState {
                 is_read_only: false,
+                status_message: None,
                 commits: Default::default(),
                 files,
             },
@@ -1159,6 +1183,7 @@ qux2
                 base: None,
                 output: None,
                 read_only: false,
+                status_message: None,
                 dry_run: false,
             },
         )?;
@@ -1168,6 +1193,7 @@ qux2
             &write_root,
             RecordState {
                 is_read_only: false,
+                status_message: None,
                 commits: Default::default(),
                 files,
             },
@@ -1243,6 +1269,7 @@ Hello world 4
                 left: "left".into(),
                 right: "right".into(),
                 read_only: false,
+                status_message: None,
                 dry_run: false,
                 base: Some("base".into()),
                 output: Some("output".into()),
@@ -1300,6 +1327,7 @@ Hello world 4
             &write_root,
             RecordState {
                 is_read_only: false,
+                status_message: None,
                 commits: Default::default(),
                 files,
             },
@@ -1378,6 +1406,7 @@ Hello world 2
                 left: "left".into(),
                 right: "right".into(),
                 read_only: false,
+                status_message: None,
                 dry_run: false,
                 base: None,
                 output: None,
@@ -1423,6 +1452,7 @@ Hello world 2
             &write_root,
             RecordState {
                 is_read_only: false,
+                status_message: None,
                 commits: Default::default(),
                 files: files.clone(),
             },
@@ -1443,6 +1473,7 @@ Hello world 2
             &write_root,
             RecordState {
                 is_read_only: false,
+                status_message: None,
                 commits: Default::default(),
                 files: files.clone(),
             },
@@ -1477,6 +1508,7 @@ Hello world 2
             &write_root,
             RecordState {
                 is_read_only: false,
+                status_message: None,
                 commits: Default::default(),
                 files: files.clone(),
             },

--- a/scm-diff-editor/tests/test_scm_diff_editor.rs
+++ b/scm-diff-editor/tests/test_scm_diff_editor.rs
@@ -35,6 +35,7 @@ qux2
             base: None,
             output: None,
             read_only: false,
+            status_message: None,
             dry_run: false,
         },
     )?;
@@ -94,6 +95,7 @@ qux2
         &write_root,
         RecordState {
             is_read_only: false,
+            status_message: None,
             commits: Default::default(),
             files,
         },
@@ -156,6 +158,7 @@ qux2
             base: None,
             output: None,
             read_only: false,
+            status_message: None,
             dry_run: false,
         },
     )?;
@@ -165,6 +168,7 @@ qux2
         &write_root,
         RecordState {
             is_read_only: false,
+            status_message: None,
             commits: Default::default(),
             files,
         },
@@ -219,6 +223,7 @@ fn test_diff_absent_left() -> Result<()> {
             base: None,
             output: None,
             read_only: false,
+            status_message: None,
             dry_run: false,
         },
     )?;
@@ -257,6 +262,7 @@ fn test_diff_absent_left() -> Result<()> {
         &write_root,
         RecordState {
             is_read_only: false,
+            status_message: None,
             commits: Default::default(),
             files,
         },
@@ -301,6 +307,7 @@ fn test_diff_absent_right() -> Result<()> {
             base: None,
             output: None,
             read_only: false,
+            status_message: None,
             dry_run: false,
         },
     )?;
@@ -339,6 +346,7 @@ fn test_diff_absent_right() -> Result<()> {
         &write_root,
         RecordState {
             is_read_only: false,
+            status_message: None,
             commits: Default::default(),
             files,
         },
@@ -381,6 +389,7 @@ fn test_reject_diff_non_files() -> Result<()> {
             base: None,
             output: None,
             read_only: false,
+            status_message: None,
             dry_run: false,
         },
     );
@@ -415,6 +424,7 @@ fn test_diff_files_in_subdirectories() -> Result<()> {
             base: None,
             output: None,
             read_only: false,
+            status_message: None,
             dry_run: false,
         },
     )?;
@@ -424,6 +434,7 @@ fn test_diff_files_in_subdirectories() -> Result<()> {
         &write_root,
         RecordState {
             is_read_only: false,
+            status_message: None,
             commits: Default::default(),
             files,
         },
@@ -479,6 +490,7 @@ fn test_dir_diff_no_changes() -> Result<()> {
             base: None,
             output: None,
             read_only: false,
+            status_message: None,
             dry_run: false,
         },
     )?;
@@ -488,6 +500,7 @@ fn test_dir_diff_no_changes() -> Result<()> {
         &write_root,
         RecordState {
             is_read_only: false,
+            status_message: None,
             commits: Default::default(),
             files,
         },
@@ -563,6 +576,7 @@ Hello world 4
             left: "left".into(),
             right: "right".into(),
             read_only: false,
+            status_message: None,
             dry_run: false,
             base: Some("base".into()),
             output: Some("output".into()),
@@ -620,6 +634,7 @@ Hello world 4
         &write_root,
         RecordState {
             is_read_only: false,
+            status_message: None,
             commits: Default::default(),
             files,
         },
@@ -698,6 +713,7 @@ Hello world 2
             left: "left".into(),
             right: "right".into(),
             read_only: false,
+            status_message: None,
             dry_run: false,
             base: None,
             output: None,
@@ -743,6 +759,7 @@ Hello world 2
         &write_root,
         RecordState {
             is_read_only: false,
+            status_message: None,
             commits: Default::default(),
             files: files.clone(),
         },
@@ -763,6 +780,7 @@ Hello world 2
         &write_root,
         RecordState {
             is_read_only: false,
+            status_message: None,
             commits: Default::default(),
             files: files.clone(),
         },
@@ -797,6 +815,7 @@ Hello world 2
         &write_root,
         RecordState {
             is_read_only: false,
+            status_message: None,
             commits: Default::default(),
             files: files.clone(),
         },

--- a/scm-record/benches/benches.rs
+++ b/scm-record/benches/benches.rs
@@ -21,6 +21,7 @@ fn bench_record(c: &mut Criterion) {
         };
         let record_state = RecordState {
             is_read_only: false,
+            status_message: None,
             commits: Default::default(),
             files: vec![File {
                 old_path: None,

--- a/scm-record/examples/load_json.rs
+++ b/scm-record/examples/load_json.rs
@@ -31,6 +31,7 @@ fn main() {
         Ok(result) => {
             let RecordState {
                 is_read_only: _,
+                status_message: _,
                 commits: _,
                 files,
             } = result;

--- a/scm-record/examples/static_contents.rs
+++ b/scm-record/examples/static_contents.rs
@@ -94,6 +94,7 @@ fn main() {
     ];
     let record_state = RecordState {
         is_read_only: false,
+        status_message: Some("Select changes to commit".to_string()),
         commits: Default::default(),
         files,
     };
@@ -104,6 +105,7 @@ fn main() {
         Ok(result) => {
             let RecordState {
                 is_read_only: _,
+                status_message: _,
                 commits: _,
                 files,
             } = result;

--- a/scm-record/src/types.rs
+++ b/scm-record/src/types.rs
@@ -18,6 +18,11 @@ pub struct RecordState<'a> {
     /// changed by the user.
     pub is_read_only: bool,
 
+    /// An optional status message to display at the bottom of the screen.
+    /// This can be used to provide context or instructions to the user.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub status_message: Option<String>,
+
     /// The commits containing the selected changes. Each changed section be
     /// assigned to exactly one commit.
     ///
@@ -38,6 +43,24 @@ pub struct RecordState<'a> {
     /// The state of each file. This is rendered in order, so you may want to
     /// sort this list by path before providing it.
     pub files: Vec<File<'a>>,
+}
+
+impl RecordState<'_> {
+    /// Create a new RecordState for testing purposes.
+    #[cfg(test)]
+    pub fn for_test(
+        is_read_only: bool,
+        status_message: Option<String>,
+        commits: Vec<Commit>,
+        files: Vec<File<'_>>,
+    ) -> RecordState<'_> {
+        RecordState {
+            is_read_only,
+            status_message,
+            commits,
+            files,
+        }
+    }
 }
 
 /// An error which occurred when attempting to record changes.

--- a/scm-record/src/ui.rs
+++ b/scm-record/src/ui.rs
@@ -861,6 +861,7 @@ impl<'state, 'input> Recorder<'state, 'input> {
     ) -> AppView<'state> {
         let RecordState {
             is_read_only,
+            status_message,
             commits,
             files,
         } = &self.state;
@@ -891,9 +892,11 @@ impl<'state, 'input> Recorder<'state, 'input> {
                 })
                 .collect(),
         };
+        let status_bar = status_message.as_ref().map(|message| StatusBar { message });
         AppView {
             debug_info: None,
             menu_bar,
+            status_bar,
             commit_view_mode: self.commit_view_mode,
             commit_views,
             quit_dialog: self.quit_dialog.clone(),
@@ -1256,6 +1259,7 @@ impl<'state, 'input> Recorder<'state, 'input> {
             files: _,
             commits,
             is_read_only: _,
+            status_message: _,
         } = &self.state;
         Ok(commits
             .iter()
@@ -1274,6 +1278,7 @@ impl<'state, 'input> Recorder<'state, 'input> {
             files,
             commits: _,
             is_read_only: _,
+            status_message: _,
         } = &self.state;
         let mut result = 0;
         for (file_idx, _file) in files.iter().enumerate() {
@@ -1687,7 +1692,8 @@ impl<'state, 'input> Recorder<'state, 'input> {
                         ComponentId::App
                         | ComponentId::AppFiles
                         | ComponentId::MenuHeader
-                        | ComponentId::CommitMessageView => false,
+                        | ComponentId::CommitMessageView
+                        | ComponentId::StatusBar => false,
                         ComponentId::MenuBar
                         | ComponentId::MenuItem(_)
                         | ComponentId::Menu(_)
@@ -1716,6 +1722,7 @@ impl<'state, 'input> Recorder<'state, 'input> {
             | ComponentId::AppFiles
             | ComponentId::MenuHeader
             | ComponentId::CommitMessageView
+            | ComponentId::StatusBar
             | ComponentId::QuitDialog => StateUpdate::None,
             ComponentId::MenuBar => StateUpdate::UnfocusMenuBar,
             ComponentId::Menu(section_idx) => StateUpdate::ClickMenu {
@@ -2315,6 +2322,7 @@ enum ComponentId {
     SelectableItem(SelectionKey),
     ToggleBox(SelectionKey),
     ExpandBox(SelectionKey),
+    StatusBar,
     QuitDialog,
     QuitDialogButton(QuitDialogButtonId),
     HelpDialog,
@@ -2404,6 +2412,7 @@ struct AppDebugInfo {
 struct AppView<'a> {
     debug_info: Option<AppDebugInfo>,
     menu_bar: MenuBar<'a>,
+    status_bar: Option<StatusBar<'a>>,
     commit_view_mode: CommitViewMode,
     commit_views: Vec<CommitView<'a>>,
     quit_dialog: Option<QuitDialog>,
@@ -2421,6 +2430,7 @@ impl Component for AppView<'_> {
         let Self {
             debug_info,
             menu_bar,
+            status_bar,
             commit_view_mode,
             commit_views,
             quit_dialog,
@@ -2434,6 +2444,7 @@ impl Component for AppView<'_> {
         let viewport_rect = viewport.mask_rect();
 
         let menu_bar_height = 1usize;
+        let status_bar_height = if status_bar.is_some() { 1usize } else { 0usize };
         let commit_view_width = match commit_view_mode {
             CommitViewMode::Inline => viewport.rect().width,
             CommitViewMode::Adjacent => {
@@ -2446,7 +2457,11 @@ impl Component for AppView<'_> {
             x: viewport_rect.x,
             y: viewport_rect.y + menu_bar_height.unwrap_isize(),
             width: Some(viewport_rect.width),
-            height: None,
+            height: Some(
+                viewport_rect
+                    .height
+                    .saturating_sub(menu_bar_height + status_bar_height),
+            ),
         };
         viewport.with_mask(commit_views_mask, |viewport| {
             let mut commit_view_x = 0;
@@ -2471,6 +2486,11 @@ impl Component for AppView<'_> {
         });
 
         viewport.draw_component(x, viewport_rect.y, menu_bar);
+
+        if let Some(status_bar) = status_bar {
+            let status_bar_y = viewport_rect.y + viewport_rect.height.unwrap_isize() - 1;
+            viewport.draw_component(x, status_bar_y, status_bar);
+        }
 
         if let Some(quit_dialog) = quit_dialog {
             viewport.draw_component(0, 0, quit_dialog);
@@ -2744,6 +2764,39 @@ impl Component for MenuBar<'_> {
             }
             x += rect.width.unwrap_isize() + 1;
         }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct StatusBar<'a> {
+    message: &'a str,
+}
+
+impl Component for StatusBar<'_> {
+    type Id = ComponentId;
+
+    fn id(&self) -> Self::Id {
+        ComponentId::StatusBar
+    }
+
+    fn draw(&self, viewport: &mut Viewport<Self::Id>, _x: isize, y: isize) {
+        let Self { message } = self;
+
+        // Use the full width of the viewport for the status bar
+        let rect = Rect {
+            x: viewport.mask_rect().x,
+            y,
+            width: viewport.mask_rect().width,
+            height: 1,
+        };
+
+        // Draw background with inverted colors for status bar
+        viewport.draw_blank(rect);
+        highlight_rect(viewport, rect);
+
+        // Draw the status message
+        let style = Style::default().add_modifier(Modifier::REVERSED);
+        viewport.draw_span(viewport.mask_rect().x, y, &Span::styled(*message, style));
     }
 }
 
@@ -3732,6 +3785,7 @@ mod tests {
 
         let state = RecordState {
             is_read_only: false,
+            status_message: None,
             commits: vec![Commit::default(), Commit::default()],
             files: vec![File {
                 old_path: None,

--- a/scm-record/tests/test_scm_record.rs
+++ b/scm-record/tests/test_scm_record.rs
@@ -14,6 +14,8 @@ type TestResult = Result<(), scm_record::RecordError>;
 fn example_contents() -> RecordState<'static> {
     RecordState {
         is_read_only: false,
+        // status_message: Some("Test status message".to_string()),
+        status_message: None,
         commits: Default::default(),
         files: vec![
             File {
@@ -541,6 +543,7 @@ fn test_quit_dialog_buttons() -> TestResult {
 fn test_enter_next() -> TestResult {
     let state = RecordState {
         is_read_only: false,
+        status_message: None,
         commits: Default::default(),
         files: vec![
             File {
@@ -626,6 +629,7 @@ fn test_enter_next() -> TestResult {
 fn test_file_mode_change() -> TestResult {
     let state = RecordState {
         is_read_only: false,
+        status_message: None,
         commits: Default::default(),
         files: vec![
             File {
@@ -674,6 +678,7 @@ fn test_file_mode_change() -> TestResult {
     insta::assert_debug_snapshot!(recorder.run()?, @r###"
     RecordState {
         is_read_only: false,
+        status_message: None,
         commits: [
             Commit {
                 message: None,
@@ -751,6 +756,7 @@ fn test_abbreviate_unchanged_sections() -> TestResult {
     let middle_length = section_length + 1;
     let state = RecordState {
         is_read_only: false,
+        status_message: None,
         commits: Default::default(),
         files: vec![File {
             old_path: None,
@@ -934,6 +940,7 @@ fn test_no_abbreviate_short_unchanged_sections() -> TestResult {
     let middle_length = num_context_lines * 2;
     let state = RecordState {
         is_read_only: false,
+        status_message: None,
         commits: Default::default(),
         files: vec![File {
             old_path: None,
@@ -1011,6 +1018,7 @@ fn test_no_abbreviate_short_unchanged_sections() -> TestResult {
 fn test_record_binary_file() -> TestResult {
     let state = RecordState {
         is_read_only: false,
+        status_message: None,
         commits: Default::default(),
         files: vec![File {
             old_path: None,
@@ -1050,6 +1058,7 @@ fn test_record_binary_file() -> TestResult {
     assert_debug_snapshot!(state, @r###"
     RecordState {
         is_read_only: false,
+        status_message: None,
         commits: [
             Commit {
                 message: None,
@@ -1113,6 +1122,7 @@ fn test_record_binary_file() -> TestResult {
 fn test_record_binary_file_noop() -> TestResult {
     let state = RecordState {
         is_read_only: false,
+        status_message: None,
         commits: Default::default(),
         files: vec![File {
             old_path: None,
@@ -1147,6 +1157,7 @@ fn test_record_binary_file_noop() -> TestResult {
     assert_debug_snapshot!(state, @r###"
     RecordState {
         is_read_only: false,
+        status_message: None,
         commits: [
             Commit {
                 message: None,
@@ -1308,6 +1319,7 @@ fn test_mouse_support() -> TestResult {
 fn test_mouse_click_checkbox() -> TestResult {
     let state = RecordState {
         is_read_only: false,
+        status_message: None,
         commits: Default::default(),
         files: vec![
             File {
@@ -1373,6 +1385,7 @@ fn test_mouse_click_checkbox() -> TestResult {
 fn test_mouse_click_wide_line() -> TestResult {
     let state = RecordState {
         is_read_only: false,
+        status_message: None,
         commits: Default::default(),
         files: vec![File {
             old_path: None,
@@ -1462,6 +1475,7 @@ fn test_mouse_click_wide_line() -> TestResult {
 fn test_mouse_click_dialog_buttons() -> TestResult {
     let state = RecordState {
         is_read_only: false,
+        status_message: None,
         commits: Default::default(),
         files: vec![File {
             old_path: None,
@@ -1514,6 +1528,7 @@ fn test_mouse_click_dialog_buttons() -> TestResult {
 fn test_render_old_path() -> TestResult {
     let state = RecordState {
         is_read_only: false,
+        status_message: None,
         commits: Default::default(),
         files: vec![File {
             old_path: Some(Cow::Borrowed(Path::new("foo"))),
@@ -2300,6 +2315,7 @@ fn test_expand_menu() -> TestResult {
 fn test_read_only() -> TestResult {
     let state = RecordState {
         is_read_only: true,
+        status_message: None,
         ..example_contents()
     };
     let initial = TestingScreenshot::default();
@@ -2400,6 +2416,7 @@ fn test_read_only() -> TestResult {
     insta::assert_debug_snapshot!(state, @r###"
     RecordState {
         is_read_only: true,
+        status_message: None,
         commits: [
             Commit {
                 message: None,
@@ -2554,6 +2571,7 @@ fn test_toggle_unchanged_line() -> TestResult {
     insta::assert_debug_snapshot!(state, @r###"
     RecordState {
         is_read_only: false,
+        status_message: None,
         commits: [
             Commit {
                 message: None,
@@ -2680,6 +2698,7 @@ fn test_toggle_unchanged_line() -> TestResult {
 fn test_max_file_view_width() -> TestResult {
     let state = RecordState {
         is_read_only: false,
+        status_message: None,
         commits: Default::default(),
         files: vec![File {
             old_path: None,
@@ -3547,6 +3566,7 @@ fn test_deserialize() -> TestResult {
 fn test_no_files() -> TestResult {
     let state = RecordState {
         is_read_only: false,
+        status_message: None,
         commits: Default::default(),
         files: vec![],
     };
@@ -3572,9 +3592,39 @@ fn test_no_files() -> TestResult {
 }
 
 #[test]
+fn test_status_message() -> TestResult {
+    let state = RecordState {
+        is_read_only: false,
+        status_message: Some("Test status message".to_string()),
+        commits: Default::default(),
+        files: vec![],
+    };
+    let initial = TestingScreenshot::default();
+    let mut input = TestingInput::new(
+        80,
+        6,
+        [Event::ExpandAll, initial.event(), Event::QuitAccept],
+    );
+    let recorder = Recorder::new(state, &mut input);
+    recorder.run()?;
+
+    insta::assert_snapshot!(initial, @r###"
+    "[File] [Edit] [Select] [View]                                                   "
+    "                                                                                "
+    "                    There are no changes to view.                               "
+    "                                                                                "
+    "                                                                                "
+    "Test status message                                                             "
+    "###);
+
+    Ok(())
+}
+
+#[test]
 fn test_tabs_in_files() -> TestResult {
     let state = RecordState {
         is_read_only: false,
+        status_message: None,
         commits: Default::default(),
         files: vec![File {
             old_path: None,
@@ -3683,6 +3733,7 @@ fn test_tabs_in_files() -> TestResult {
 fn test_carriage_return() -> TestResult {
     let state = RecordState {
         is_read_only: false,
+        status_message: None,
         commits: Default::default(),
         files: vec![File {
             old_path: None,
@@ -3766,6 +3817,7 @@ fn test_carriage_return() -> TestResult {
 fn test_some_control_characters() -> TestResult {
     let state = RecordState {
         is_read_only: false,
+        status_message: None,
         commits: Default::default(),
         files: vec![File {
             old_path: None,
@@ -3808,6 +3860,7 @@ fn test_some_control_characters() -> TestResult {
 fn test_non_printing_characters() -> TestResult {
     let state = RecordState {
         is_read_only: false,
+        status_message: None,
         commits: Default::default(),
         files: vec![File {
             old_path: None,


### PR DESCRIPTION
This is an attempt to implement #125.

Note that the status message can also be set through the command line with the optional --status-message argument.

If this is OK we could also add a --title-message that shows a message at the top of the screen (above the menubar).
