### PR TITLE
build: release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+## [0.9.0] - 2025-11-12
+
+### Changed
+
+- (#91) The "?" help window now displays keyboard shortcuts.
+- (#110) Do not wraparound when changing to next/prev selection.
+
 ## [0.8.0] - 2025-03-15
 
 ### Changed
 
 - BREAKING (#93): File mode changes (including file creation and file deletion) should now always be represented as `Section::FileMode`.
 - (#95) Some selections/deselections are now performed automatically to prevent impossible combinations (like trying to delete a file but leave lines in it)
-- (#110) Do not wraparound when changing to next/prev selection.
 
 ## [0.7.0] - 2025-03-15
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "scm-diff-editor"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "clap",
  "diffy",
@@ -1068,7 +1068,7 @@ dependencies = [
 
 [[package]]
 name = "scm-record"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "assert_matches",
  "cassowary",

--- a/scm-diff-editor/Cargo.toml
+++ b/scm-diff-editor/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 name = "scm-diff-editor"
 repository = "https://github.com/arxanas/scm-record"
-version = "0.8.0"
+version = "0.9.0"
 
 # Keep in sync with `scm-record/Cargo.toml`.
 rust-version = "1.85"
@@ -15,7 +15,7 @@ rust-version = "1.85"
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
 diffy = "0.4"
-scm-record = { version = "0.8", path = "../scm-record" }
+scm-record = { version = "0.9", path = "../scm-record" }
 sha1 = "0.10"
 thiserror = "2.0.3"
 tracing = "0.1.40"

--- a/scm-record/Cargo.toml
+++ b/scm-record/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 name = "scm-record"
 repository = "https://github.com/arxanas/scm-record"
-version = "0.8.0"
+version = "0.9.0"
 
 # Main consumers to consider:
 # - git-branchless: https://github.com/arxanas/git-branchless/blob/master/Cargo.toml


### PR DESCRIPTION
This also includes updates CHANGELOG.md:

- Add an entry for #91.
- Move #110 to this new release version. It's entry was erroneously added to the changelog for v0.8.0.