### PR TITLE
Fix left navigation from file mode sections

### DIFF
--- a/scm-record/src/ui.rs
+++ b/scm-record/src/ui.rs
@@ -1521,14 +1521,19 @@ impl<'state, 'input> Recorder<'state, 'input> {
             selection_key @ SelectionKey::File(_) => {
                 StateUpdate::SetExpandItem(selection_key, false)
             }
-            selection_key @ SelectionKey::Section(SectionKey {
-                commit_idx,
-                file_idx,
-                section_idx: _,
-            }) => {
+            selection_key @ SelectionKey::Section(
+                section_key @ SectionKey {
+                    commit_idx,
+                    file_idx,
+                    section_idx: _,
+                },
+            ) => {
                 // If folding is requested and the selection is expanded,
                 // collapse it. Otherwise, move the selection to the file.
-                if fold_section && self.expanded_items.contains(&selection_key) {
+                if fold_section
+                    && matches!(self.section(section_key), Ok(Section::Changed { .. }))
+                    && self.expanded_items.contains(&selection_key)
+                {
                     StateUpdate::SetExpandItem(selection_key, false)
                 } else {
                     StateUpdate::SelectItem {

--- a/scm-record/tests/test_scm_record.rs
+++ b/scm-record/tests/test_scm_record.rs
@@ -1650,6 +1650,55 @@ fn test_expand_line_noop() -> TestResult {
 }
 
 #[test]
+fn test_focus_outer_from_file_mode_section_selects_file() -> TestResult {
+    let state = RecordState {
+        is_read_only: false,
+        commits: Default::default(),
+        files: vec![File {
+            old_path: None,
+            path: Cow::Borrowed(Path::new("foo")),
+            file_mode: FileMode::FILE_DEFAULT,
+            sections: vec![Section::FileMode {
+                is_checked: false,
+                mode: FileMode::Unix(0o600),
+            }],
+        }],
+    };
+    let section_selected = TestingScreenshot::default();
+    let file_selected = TestingScreenshot::default();
+    let mut input = TestingInput::new(
+        80,
+        5,
+        [
+            Event::FocusInner,
+            section_selected.event(),
+            Event::FocusOuter { fold_section: true },
+            file_selected.event(),
+            Event::QuitAccept,
+        ],
+    );
+    let recorder = Recorder::new(state, &mut input);
+    recorder.run()?;
+
+    insta::assert_snapshot!(section_selected, @r###"
+    "[File] [Edit] [Select] [View]                                                   "
+    "[ ] foo                                                                      [-]"
+    "  ( ) File mode set to 600                                                      "
+    "                                                                                "
+    "                                                                                "
+    "###);
+    insta::assert_snapshot!(file_selected, @r###"
+    "[File] [Edit] [Select] [View]                                                   "
+    "( ) foo                                                                      (-)"
+    "  [ ] File mode set to 600                                                      "
+    "                                                                                "
+    "                                                                                "
+    "###);
+
+    Ok(())
+}
+
+#[test]
 fn test_expand_scroll_into_view() -> TestResult {
     let state = example_contents();
     let before_expand = TestingScreenshot::default();


### PR DESCRIPTION
## Summary
- make left navigation collapse only expandable changed sections
- let left navigation move directly from file mode sections back to their file
- add a regression snapshot for the FileMode-only path

Fixes #100

## Tests
- cargo fmt --check
- cargo test -p scm-record
- cargo clippy --workspace --all-features --all-targets -- --deny warnings
- cargo test --all-features --examples --tests --workspace
- cargo test --all-features --doc --workspace
- cargo test --no-default-features --examples --tests --workspace
- cargo test --no-default-features --doc --workspace